### PR TITLE
[Cryptellation Conductor] Update candlesticks to v1.0.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.8
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.2
-	github.com/cryptellation/candlesticks v1.0.4
+	github.com/cryptellation/candlesticks v1.0.5
 	github.com/cryptellation/dbmigrator v1.0.1
 	github.com/cryptellation/health v1.1.1
 	github.com/cryptellation/runtime v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cryptellation/candlesticks v1.0.4 h1:OSU4OyIH1+iVsIfEBEjf8vdKOleeLqW0agdl7DV9NYo=
 github.com/cryptellation/candlesticks v1.0.4/go.mod h1:0R+YZ+PBJsV+jindXAzTKfCU7kq+4VpUfKhWv+028GQ=
+github.com/cryptellation/candlesticks v1.0.5 h1:LMc0RJ6W+YvQ1YYQ3nyh7OoD9+SQOHD249S/5/YIPUk=
+github.com/cryptellation/candlesticks v1.0.5/go.mod h1:0lyK2y9RNKUOGnQFkeoyMCrkTuccdcnHXx4fndYVA8Y=
 github.com/cryptellation/dbmigrator v1.0.1 h1:LdtohjurN31oWpiF4EdE7irPdB8c3Q1ghY/OZlYB5QE=
 github.com/cryptellation/dbmigrator v1.0.1/go.mod h1:WtyJbIg0tAgEZIMnOjW2sTp1hVc4jRTK1xx2PD5zssk=
 github.com/cryptellation/health v1.0.1 h1:wZp/y4z8CbSVKUWCL/+8TdPPAPWLScUrJl/YBJf5z5I=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/candlesticks** to version **v1.0.5**.

### Changes
- Updated dependency: `github.com/cryptellation/candlesticks`
- New version: `v1.0.5`

This update was automatically generated by Conductor.