### PR TITLE
fix(dependencies): update runtime to v1.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cryptellation/candlesticks v1.0.4
 	github.com/cryptellation/dbmigrator v1.0.1
 	github.com/cryptellation/health v1.1.1
-	github.com/cryptellation/runtime v1.7.0
+	github.com/cryptellation/runtime v1.8.0
 	github.com/cryptellation/ticks v1.2.1
 	github.com/cryptellation/version v1.3.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/cryptellation/health v1.1.1 h1:LerBgSsMME5P6WGqG40uKoZI7QZ5ISpRGTJ1To
 github.com/cryptellation/health v1.1.1/go.mod h1:V5JEOyvgWHMerjn5XyXllNSRHxCeCxKmWtT8YCz6W3c=
 github.com/cryptellation/runtime v1.7.0 h1:8qCi8nBAsjQyF1a2makR1JIHuI9jSSJBWGS1NRoRfWE=
 github.com/cryptellation/runtime v1.7.0/go.mod h1:EFaH6DdIGe4eEPsapFKK5uIJZNII7MIGT2eWjl09RYU=
+github.com/cryptellation/runtime v1.8.0 h1:N0271FOlLh559BPSMTFMz+odDONbKnNZ6Yt1B4yHFos=
+github.com/cryptellation/runtime v1.8.0/go.mod h1:EFaH6DdIGe4eEPsapFKK5uIJZNII7MIGT2eWjl09RYU=
 github.com/cryptellation/ticks v1.2.1 h1:onvm8kmEyBxK5ELWrzUqqCd8+6BT3LhPfBmUP11J6Vo=
 github.com/cryptellation/ticks v1.2.1/go.mod h1:tTMMu1U1e1I1J9Dp73KGh411TWrKcYmB4xORNJNPHtE=
 github.com/cryptellation/timeseries v1.1.0 h1:S5xFLGukQg+k22+L5151Na95+WjhhDKMK0hBkxfJYgo=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/runtime** to version **v1.8.0**.

### Changes
- Updated dependency: `github.com/cryptellation/runtime`
- New version: `v1.8.0`

This update was automatically generated by DepSync.