### PR TITLE
fix(dependencies): update ticks to v1.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cryptellation/dbmigrator v1.0.1
 	github.com/cryptellation/health v1.1.1
 	github.com/cryptellation/runtime v1.7.0
-	github.com/cryptellation/ticks v1.2.1
+	github.com/cryptellation/ticks v1.3.1
 	github.com/cryptellation/version v1.3.2
 	github.com/google/uuid v1.6.0
 	github.com/jmoiron/sqlx v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/cryptellation/runtime v1.7.0 h1:8qCi8nBAsjQyF1a2makR1JIHuI9jSSJBWGS1N
 github.com/cryptellation/runtime v1.7.0/go.mod h1:EFaH6DdIGe4eEPsapFKK5uIJZNII7MIGT2eWjl09RYU=
 github.com/cryptellation/ticks v1.2.1 h1:onvm8kmEyBxK5ELWrzUqqCd8+6BT3LhPfBmUP11J6Vo=
 github.com/cryptellation/ticks v1.2.1/go.mod h1:tTMMu1U1e1I1J9Dp73KGh411TWrKcYmB4xORNJNPHtE=
+github.com/cryptellation/ticks v1.3.1 h1:iMVSQIyWy+xIj9237FB4WwvP4QgweCub5dpNEoVXOtk=
+github.com/cryptellation/ticks v1.3.1/go.mod h1:8Gyw4D7WsKJR4mTQS3UyLjlG83Bx/Q1VGatsj6HNLyg=
 github.com/cryptellation/timeseries v1.1.0 h1:S5xFLGukQg+k22+L5151Na95+WjhhDKMK0hBkxfJYgo=
 github.com/cryptellation/timeseries v1.1.0/go.mod h1:SxqmKOjn/l5AXZGaLGA47oScXzpTcXtnmfom88uZdaY=
 github.com/cryptellation/version v1.3.2 h1:Qr17eHA25NYxMamZPhIfKv1j+2ZNCh0FeVqHgEcT1ic=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/ticks** to version **v1.3.1**.

### Changes
- Updated dependency: `github.com/cryptellation/ticks`
- New version: `v1.3.1`

This update was automatically generated by DepSync.