### PR TITLE
[DepSync] Update dbmigrator to v1.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.8
 require (
 	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/cryptellation/candlesticks v1.0.4
-	github.com/cryptellation/dbmigrator v1.0.1
+	github.com/cryptellation/dbmigrator v1.1.0
 	github.com/cryptellation/health v1.1.1
 	github.com/cryptellation/runtime v1.7.0
 	github.com/cryptellation/ticks v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/cryptellation/candlesticks v1.0.4 h1:OSU4OyIH1+iVsIfEBEjf8vdKOleeLqW0
 github.com/cryptellation/candlesticks v1.0.4/go.mod h1:0R+YZ+PBJsV+jindXAzTKfCU7kq+4VpUfKhWv+028GQ=
 github.com/cryptellation/dbmigrator v1.0.1 h1:LdtohjurN31oWpiF4EdE7irPdB8c3Q1ghY/OZlYB5QE=
 github.com/cryptellation/dbmigrator v1.0.1/go.mod h1:WtyJbIg0tAgEZIMnOjW2sTp1hVc4jRTK1xx2PD5zssk=
+github.com/cryptellation/dbmigrator v1.1.0 h1:n3wwqyQm2esSl+GusMEl/frYbfNm1d1fUk4LWkHvHdQ=
+github.com/cryptellation/dbmigrator v1.1.0/go.mod h1:WtyJbIg0tAgEZIMnOjW2sTp1hVc4jRTK1xx2PD5zssk=
 github.com/cryptellation/health v1.0.1 h1:wZp/y4z8CbSVKUWCL/+8TdPPAPWLScUrJl/YBJf5z5I=
 github.com/cryptellation/health v1.0.1/go.mod h1:V5JEOyvgWHMerjn5XyXllNSRHxCeCxKmWtT8YCz6W3c=
 github.com/cryptellation/health v1.1.1 h1:LerBgSsMME5P6WGqG40uKoZI7QZ5ISpRGTJ1Toe4lWo=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/dbmigrator** to version **v1.1.0**.

### Changes
- Updated dependency: `github.com/cryptellation/dbmigrator`
- New version: `v1.1.0`

This update was automatically generated by DepSync.